### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           node-version: "12.x"
       - run: npm install
-      - run: npm run build --if-present
-        env:
-          CI: true
       - name: Publish
         uses: cloudflare/wrangler-action@1.1.0
         with:


### PR DESCRIPTION
Since `npm build` is an alias to `wrangler build`, we can skip it entirely and just use wrangler-action for builds. In fact, because wrangler-action is a self-contained workflow, we only have access to the `wrangler` command while we're inside that action 🙈